### PR TITLE
fix(register): 修复邮箱验证码接口请求方式不支持 POST

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,10 +1,12 @@
 import type { EmailCodeDTO, LoginDTO, LoginVO, RegisterDTO } from './types';
-import { post } from '@/utils/request';
+import { get, post } from '@/utils/request';
 
 export const login = (data: LoginDTO) => post<LoginVO>('/auth/login', data).json();
 
-// 邮箱验证码
-export const emailCode = (data: EmailCodeDTO) => post('/resource/email/code', data).json();
+// 邮箱验证码（后端 GET /resource/email/code，按 query 参数 email 接收）
+export function emailCode(data: EmailCodeDTO) {
+  return get('/resource/email/code', { email: data.email }).json();
+}
 
 // 注册账号
 export const register = (data: RegisterDTO) => post('/auth/register', data).json();

--- a/src/api/auth/types.ts
+++ b/src/api/auth/types.ts
@@ -126,13 +126,16 @@ export interface RoleDTO {
 
 // 邮箱验证码
 export interface EmailCodeDTO {
-  username?: string;
+  /**
+   * 邮箱（后端 GET /resource/email/code 按 query 参数 email 接收）
+   */
+  email: string;
 }
 
 // 邮箱注册
 export interface RegisterDTO {
   /**
-   * 邮箱
+   * 邮箱（注册时作为用户名 username 提交给后端）
    */
   username: string;
   /**
@@ -147,4 +150,16 @@ export interface RegisterDTO {
    * 确认密码
    */
   confirmPassword?: string;
+  /**
+   * 客户端 id（后端 RegisterBody 继承 LoginBody，clientId 为必填）
+   */
+  clientId?: string;
+  /**
+   * 授权类型
+   */
+  grantType?: string;
+  /**
+   * 租户 ID
+   */
+  tenantId?: string;
 }

--- a/src/components/LoginDialog/components/FormLogin/RegistrationForm.vue
+++ b/src/components/LoginDialog/components/FormLogin/RegistrationForm.vue
@@ -66,6 +66,11 @@ async function handleSubmit() {
       username: formModel.value.username,
       password: formModel.value.password,
       code: formModel.value.code,
+      // 后端 RegisterBody 继承自 LoginBody，clientId / grantType 为必填项，
+      // 且需指定租户，否则注册会被 @Validated 拦截或落到空租户。
+      clientId: import.meta.env.VITE_CLIENT_ID,
+      grantType: 'password',
+      tenantId: '000000',
     };
     await register(params);
     ElMessage.success('注册成功');
@@ -91,7 +96,8 @@ async function getEmailCode() {
   }
   try {
     start();
-    await emailCode({ username: formModel.value.username });
+    // 后端按 query 参数 email 接收，用户端把邮箱放在 username 字段输入。
+    await emailCode({ email: formModel.value.username });
     ElMessage.success('验证码发送成功');
   }
   catch (error) {


### PR DESCRIPTION
## 背景

Closes #317

注册账号时输入邮箱点"获取验证码"，接口报错 **请求方式不支持 POST**。

## 根因

后端 `CaptchaController#emailCode` 是 `@GetMapping("/resource/email/code")`（`ruoyi-ai` 仓库 `ruoyi-admin/.../CaptchaController.java:83`），而前端 `v3.0.0 init` 里 `emailCode` 用的是 `post`：

```ts
export const emailCode = (data) => post('/resource/email/code', data).json();
```

前端 POST、后端 GET → Spring 抛 `HttpRequestMethodNotSupportedException: Request method 'POST' is not supported`，即 #317 报错。

## 修复

- `src/api/auth/index.ts`：`emailCode` 改为 `get`，参数按 query `email` 传递
- `src/components/LoginDialog/components/FormLogin/RegistrationForm.vue`：`getEmailCode()` 调用处由 `{ username }` 改为 `{ email: formModel.value.username }`
- `src/api/auth/types.ts`：`EmailCodeDTO.username?` → `email: string`；`RegisterDTO` 补 `clientId / grantType / tenantId` 字段
- `RegistrationForm.handleSubmit`：注册请求补 `clientId / grantType / tenantId`，否则后端 `RegisterBody`（继承 `LoginBody`）的 `@NotBlank` 校验会拦截注册

## 验证

- lint-staged + eslint 通过
- 手动验证待补：注册页输入邮箱 → 获取验证码 → 收到邮件验证码

🤖 Generated with [Claude Code](https://claude.com/claude-code)